### PR TITLE
fix(ProductResource pages): Remove getTranslatableLocales method

### DIFF
--- a/src/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/src/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -13,11 +13,6 @@ class CreateProduct extends CreateRecord
     #[Reactive]
     public ?string $activeLocale = null;
 
-    public static function getTranslatableLocales(): array
-    {
-        return ['en', 'ar'];
-    }
-
     protected static string $resource = ProductResource::class;
 
     protected function getHeaderActions(): array

--- a/src/Filament/Resources/ProductResource/Pages/EditProduct.php
+++ b/src/Filament/Resources/ProductResource/Pages/EditProduct.php
@@ -14,11 +14,6 @@ class EditProduct extends EditRecord
     #[Reactive]
     public ?string $activeLocale = null;
 
-    public static function getTranslatableLocales(): array
-    {
-        return ['en', 'ar'];
-    }
-
     protected function mutateFormDataBeforeFill(array $data): array
     {
         $data['prices'] = $this->getRecord()->meta('prices')??[];

--- a/src/Filament/Resources/ProductResource/Pages/ListProducts.php
+++ b/src/Filament/Resources/ProductResource/Pages/ListProducts.php
@@ -15,11 +15,6 @@ class ListProducts extends ListRecords
     #[Reactive]
     public ?string $activeLocale = null;
 
-    public static function getTranslatableLocales(): array
-    {
-        return ['en', 'ar'];
-    }
-
     protected function getHeaderActions(): array
     {
         return [


### PR DESCRIPTION
The `getTranslatableLocales` method was removed from CreateProduct, EditProduct, and ListProducts pages. This was likely done because the method may no longer be needed, or its functionality is being handled elsewhere.

Because the default language is already configured in the https://github.com/tomatophp/filament-ecommerce/blob/master/src/FilamentEcommercePlugin.php#L59 file, and users can configure a custom language when using the plugin by using the following method:

```php
->plugin(
	\TomatoPHP\FilamentEcommerce\FilamentEcommercePlugin::make()
        ->defaultLocales(['en', 'zh-CN', '...'])
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated locale handling for product creation, editing, and listing pages. The explicit locale selection option has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->